### PR TITLE
feat(usermgr): agregar función para listar usuarios con estados y roles

### DIFF
--- a/usermgr/CHANGELOG.md
+++ b/usermgr/CHANGELOG.md
@@ -7,6 +7,19 @@ y este proyecto se adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ---
 
+## [1.5.0] - 2025-06-20
+
+### Añadido
+- Función para listar usuarios (`listar_usuarios`) que muestra una tabla con el usuario, rol asignado, estado de acceso login y acceso SSH, con colores para diferenciar estados activos y bloqueados.
+- Funciones auxiliares para obtener rol de usuario y estado de acceso.
+- Interfaz de menú actualizada para incluir la opción "Ver usuarios".
+- La navegación en las listas ahora es ciclica, si llega al final (arriba) vuelve a empezar y visceversa.
+
+### Arreglado
+- Corrección en `cargar_usuarios`: se reinician los arrays `CREATED_USERS` Y `BLOCKED_USERS` al cargar usuarios, evitando acumulación de datos y errores.
+
+---
+
 ## [1.4.0] - 2025-06-20
 
 ### Añadido


### PR DESCRIPTION
- Se implementa función listar_usuarios que muestra tabla combinada de usuarios con su rol, estado de login y acceso SSH, con colores.
- Se añade lógica para obtener rol de usuario, estado de login (activo/bloqueado) y estado SSH (activo/bloqueado).
- Se mejora visualización con tabla alineada y colores para mayor claridad.
- Se corrige la función cargar_usuarios para reinicializar listas de usuarios evitando duplicados y errores en bloqueos y desbloqueos.
- La navegación en las listas ahora es ciclica, si llega al final (arriba) vuelve a empezar y visceversa.
- Actualiza CHANGELOG.md con detalles de la versión 1.5.0